### PR TITLE
Fix code scanning alert no. 225: Code injection

### DIFF
--- a/influent-release-release-1.2.0/influent-client/src/main/requirejs/r.js
+++ b/influent-release-release-1.2.0/influent-client/src/main/requirejs/r.js
@@ -212,8 +212,8 @@ var requirejs, require, define, xpcUtil;
 
         readFile = xpcUtil.readFile;
 
-        exec = function (string) {
-            return eval(string);
+        exec = function (config) {
+            return require.config(config);
         };
 
         exists = function (fileName) {
@@ -25064,7 +25064,7 @@ define('build', function (require) {
             dir = dir.split('/');
             dir.pop();
             dir = dir.join('/');
-            exec("require({baseUrl: '" + dir + "'});");
+            exec({ baseUrl: dir });
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/ZoneCog/influentall/security/code-scanning/225](https://github.com/ZoneCog/influentall/security/code-scanning/225)

To fix the problem, we should avoid using `eval` to execute code derived from user-controllable input. Instead, we can use safer alternatives to achieve the same functionality. In this case, we can use the `require` function directly to set the `baseUrl` without evaluating a string.

- Replace the `exec` function to avoid using `eval`.
- Modify the `setBaseUrl` function to use `require.config` directly instead of constructing a string for `eval`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
