### PR TITLE
Fix code scanning alert no. 223: Code injection

### DIFF
--- a/influent-release-Release-2.0.0-be/influent-client/src/main/requirejs/r.js
+++ b/influent-release-Release-2.0.0-be/influent-client/src/main/requirejs/r.js
@@ -212,8 +212,10 @@ var requirejs, require, define, xpcUtil;
 
         readFile = xpcUtil.readFile;
 
-        exec = function (string) {
-            return eval(string);
+        exec = function (config) {
+            if (typeof require === 'function' && typeof require.config === 'function') {
+                require.config(config);
+            }
         };
 
         exists = function (fileName) {
@@ -25064,7 +25066,7 @@ define('build', function (require) {
             dir = dir.split('/');
             dir.pop();
             dir = dir.join('/');
-            exec("require({baseUrl: '" + dir + "'});");
+            exec({baseUrl: dir});
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/ZoneCog/influentall/security/code-scanning/223](https://github.com/ZoneCog/influentall/security/code-scanning/223)

To fix the problem, we need to avoid using `eval` to execute code derived from user input. Instead, we can use safer alternatives to achieve the same functionality. In this case, we can replace the `exec` function with a method that sets the `baseUrl` directly without using `eval`.

1. Replace the `exec` function with a safer implementation that does not use `eval`.
2. Modify the `setBaseUrl` function to set the `baseUrl` directly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
